### PR TITLE
Trocar bc por awk

### DIFF
--- a/info.sh
+++ b/info.sh
@@ -105,11 +105,11 @@ hpmp () {
  FIXHP=$(grep -o -E '\(([0-9]+)\)' $TMP/TRAIN|sed 's/[()]//g')
  FIXMP=$(grep -o -E ': [0-9]+' $TMP/TRAIN | sed -n '5s/: //p')
  #printf "$FIXHP e $FIXMP\n"
- 
+
  #/Calculates percentage of HP and MP.
  #/Needs to run -fix at least once before
- HPPER=$(echo "scale=2; $NOWHP / $FIXHP * 100" | bc)
- MPPER=$(echo "scale=2; $NOWMP / $FIXMP * 100" | bc)
+ HPPER=$(awk -v nowhp="$NOWHP" -v fixhp="$FIXHP" 'BEGIN { printf "%.2f", nowhp / fixhp * 100 }')
+ MPPER=$(awk -v nowmp="$NOWMP" -v fixmp="$FIXMP" 'BEGIN { printf "%.2f", nowmp / fixmp * 100 }')
 
  #HPPER=$(awk -v fixhp="$FIXHP" -v nowhp="$NOWHP" 'BEGIN { printf "%.0f", fixhp * nowhp / 100 }')
  #MPPER=$(awk -v fixmp="$FIXMP" -v nowmp="$NOWMP" 'BEGIN { printf "%.0f", fixmp * nowmp / 100 }')

--- a/undying.sh
+++ b/undying.sh
@@ -69,10 +69,9 @@ undying_start () {
 
 
    hpmp -now
-   #/hp20%+, mp60%+
+   #/hp20%+, mp10%+
 
-   #if awk -v hpper="$HPPER" 'BEGIN { exit !(hpper > 20) }' && awk -v mpper="$MPPER" 'BEGIN { exit !(mpper > 60) }'; then
-   if (( $(echo "$HPPER > 30" | bc -l) )); then
+   if awk -v hpper="$HPPER" 'BEGIN { exit !(hpper > 20) }' && awk -v mpper="$MPPER" 'BEGIN { exit !(mpper > 10) }'; then
     arena_takeHelp
     arena_fullmana
    fi


### PR DESCRIPTION
awk já está como padrão na maioria dos GNU/Linux, se não todos.

Ele testa números, letras, e outros caracteres com os mesmo operadores; ==, !=; >, <, etc.

Também calcula com precisão, e pode limitar as casas decimais  no printf embutido no mesmo.